### PR TITLE
added v0.1.1 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,6 @@
+#### 0.1.1 April 13 2018 ####
+* Implemented [Add option to disable metric postfixes](https://github.com/petabridge/Petabridge.Monitoring.PCF/issues/8)
+* Upgraded to [Akka.Bootstrap.PCF v0.1.2](https://github.com/petabridge/akkadotnet-bootstrap/tree/dev/src/Akka.Bootstrap.PCF)
+
 #### 0.1.0 April 12 2018 ####
 First release of `Petabridge.Monitoring.PCF`.

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.1.0</VersionPrefix>
-    <PackageReleaseNotes>First release of `Petabridge.Monitoring.PCF`.</PackageReleaseNotes>
+    <VersionPrefix>0.1.1</VersionPrefix>
+    <PackageReleaseNotes>Implemented [Add option to disable metric postfixes](https://github.com/petabridge/Petabridge.Monitoring.PCF/issues/8)
+Upgraded to [Akka.Bootstrap.PCF v0.1.2](https://github.com/petabridge/akkadotnet-bootstrap/tree/dev/src/Akka.Bootstrap.PCF)</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/Petabridge.Monitoring.PCF


### PR DESCRIPTION
#### 0.1.1 April 13 2018 ####
* Implemented [Add option to disable metric postfixes](https://github.com/petabridge/Petabridge.Monitoring.PCF/issues/8)
* Upgraded to [Akka.Bootstrap.PCF v0.1.2](https://github.com/petabridge/akkadotnet-bootstrap/tree/dev/src/Akka.Bootstrap.PCF)