### PR TITLE
v0.1.2 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 0.1.2 April 26 2018 ####
+* Upgraded to [Akka.Bootstrap.PCF v0.1.3](https://github.com/petabridge/akkadotnet-bootstrap/tree/dev/src/Akka.Bootstrap.PCF)
+* Added XML-DOC support to NuGet packages.
+
 #### 0.1.1 April 13 2018 ####
 * Implemented [Add option to disable metric postfixes](https://github.com/petabridge/Petabridge.Monitoring.PCF/issues/8)
 * Upgraded to [Akka.Bootstrap.PCF v0.1.2](https://github.com/petabridge/akkadotnet-bootstrap/tree/dev/src/Akka.Bootstrap.PCF)

--- a/src/Petabridge.Monitoring.PCF.Tests/Petabridge.Monitoring.PCF.Tests.csproj
+++ b/src/Petabridge.Monitoring.PCF.Tests/Petabridge.Monitoring.PCF.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.5" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.6" />
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Petabridge.Monitoring.PCF/Petabridge.Monitoring.PCF.csproj
+++ b/src/Petabridge.Monitoring.PCF/Petabridge.Monitoring.PCF.csproj
@@ -8,6 +8,11 @@
   </PropertyGroup>
 
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\Petabridge.Monitoring.PCF.xml</DocumentationFile>
+  </PropertyGroup>
+
+
   <ItemGroup>
     <PackageReference Include="Akka.Bootstrap.PCF" Version="0.1.3" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />

--- a/src/Petabridge.Monitoring.PCF/Petabridge.Monitoring.PCF.csproj
+++ b/src/Petabridge.Monitoring.PCF/Petabridge.Monitoring.PCF.csproj
@@ -9,7 +9,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Akka.Bootstrap.PCF" Version="0.1.2" />
+    <PackageReference Include="Akka.Bootstrap.PCF" Version="0.1.3" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Phobos.Actor.Common" Version="1.0.0" />

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.1.1</VersionPrefix>
-    <PackageReleaseNotes>Implemented [Add option to disable metric postfixes](https://github.com/petabridge/Petabridge.Monitoring.PCF/issues/8)
-Upgraded to [Akka.Bootstrap.PCF v0.1.2](https://github.com/petabridge/akkadotnet-bootstrap/tree/dev/src/Akka.Bootstrap.PCF)</PackageReleaseNotes>
+    <VersionPrefix>0.1.2</VersionPrefix>
+    <PackageReleaseNotes>Upgraded to [Akka.Bootstrap.PCF v0.1.3](https://github.com/petabridge/akkadotnet-bootstrap/tree/dev/src/Akka.Bootstrap.PCF)
+Added XML-DOC support to NuGet packages.</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/Petabridge.Monitoring.PCF


### PR DESCRIPTION
#### 0.1.2 April 26 2018 ####
* Upgraded to [Akka.Bootstrap.PCF v0.1.3](https://github.com/petabridge/akkadotnet-bootstrap/tree/dev/src/Akka.Bootstrap.PCF)
* Added XML-DOC support to NuGet packages.